### PR TITLE
[Feature/Session] 로그아웃, 액세스 토큰 재발급 API

### DIFF
--- a/src/main/java/com/glimps/glimpsserver/GlimpsServerApplication.java
+++ b/src/main/java/com/glimps/glimpsserver/GlimpsServerApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class GlimpsServerApplication {
 

--- a/src/main/java/com/glimps/glimpsserver/GlimpsServerApplication.java
+++ b/src/main/java/com/glimps/glimpsserver/GlimpsServerApplication.java
@@ -2,7 +2,9 @@ package com.glimps.glimpsserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GlimpsServerApplication {
 

--- a/src/main/java/com/glimps/glimpsserver/common/authentication/UserAuthentication.java
+++ b/src/main/java/com/glimps/glimpsserver/common/authentication/UserAuthentication.java
@@ -27,10 +27,6 @@ public class UserAuthentication extends AbstractAuthenticationToken {
 		super.setAuthenticated(true);
 	}
 
-	// public static UserAuthentication getAnonymous() {
-	// 	return new UserAuthentication(List.of(new SimpleGrantedAuthority("ROLE_UNKNOWN")));
-	// }
-
 	@Override
 	public Object getCredentials() {
 		return null;

--- a/src/main/java/com/glimps/glimpsserver/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/glimps/glimpsserver/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.glimps.glimpsserver.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/glimps/glimpsserver/common/config/MatcherConfig.java
+++ b/src/main/java/com/glimps/glimpsserver/common/config/MatcherConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Configuration
 public class MatcherConfig {
 
-	private static final List<String> authURL = List.of("/api/v1/user/**", "/api/v1/logout", "/test");
+	private static final List<String> authURL = List.of("/api/v1/users", "/api/v1/logout", "/test");
 	private static final List<String> adminURL = List.of("/admin/**");
 
 	@Bean

--- a/src/main/java/com/glimps/glimpsserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/glimps/glimpsserver/common/config/SecurityConfig.java
@@ -1,19 +1,23 @@
 package com.glimps.glimpsserver.common.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glimps.glimpsserver.common.filter.CustomAccessDeniedHandler;
 import com.glimps.glimpsserver.common.filter.CustomAuthenticationEntryPoint;
 import com.glimps.glimpsserver.common.filter.JwtAuthenticationFilter;
 import com.glimps.glimpsserver.common.oauth.handler.OAuth2SuccessHandler;
 import com.glimps.glimpsserver.common.oauth.service.CustomOAuth2UserService;
+import com.glimps.glimpsserver.session.application.AuthenticationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,11 +27,11 @@ public class SecurityConfig {
 
 	private final OAuth2SuccessHandler successHandler;
 	private final CustomOAuth2UserService oAuth2UserService;
-
-	private final JwtAuthenticationFilter jwtFilter;
-
 	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 	private final CustomAccessDeniedHandler accessDeniedHandler;
+	private final AuthenticationService authenticationService;
+	private final ObjectMapper mapper;
+	private final List<RequestMatcher> matchers;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -58,9 +62,16 @@ public class SecurityConfig {
 			.antMatchers(MatcherConfig.getAdminURL().toArray(new String[0])).hasRole("ADMIN")
 			.anyRequest().permitAll();
 
-		http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(new JwtAuthenticationFilter(authenticationService, mapper, matchers),
+			UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}
+
+	// @Bean
+	// public JwtAuthenticationFilter jwtFilter(AuthenticationService authenticationService, ObjectMapper mapper,
+	// 	List<RequestMatcher> matchers) {
+	// 	return new JwtAuthenticationFilter(authenticationService, mapper, matchers);
+	// }
 
 }

--- a/src/main/java/com/glimps/glimpsserver/common/config/SwaggerConfig.java
+++ b/src/main/java/com/glimps/glimpsserver/common/config/SwaggerConfig.java
@@ -1,0 +1,65 @@
+package com.glimps.glimpsserver.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.glimps.glimpsserver.common.authentication.UserAuthentication;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.OAS_30)
+			.select()   // ApiSelectorBuilder 생성
+			.apis(RequestHandlerSelectors.basePackage("com.glimps.glimpsserver"))   // API 패키지 경로
+			// .paths(PathSelectors.ant("/api/**"))    //path 조건에 따라서 API 문서화
+			.paths(PathSelectors.any())       // <- 모든 path 에 대해서 명세 표시
+			.build()
+			.apiInfo(apiInfo()) // API 문서에 대한 정보 추가
+			.useDefaultResponseMessages(false)  // swagger 에서 제공하는 기본 응답 코드 설명 제거
+			.securityContexts(Arrays.asList(securityContext()))
+			.securitySchemes(Arrays.asList(apiKey()))
+			.ignoredParameterTypes(UserAuthentication.class);
+	}
+
+	private ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+			.title("Glims API 문서")
+			.description("API 스펙에 대해서 설명해주는 문서입니다. 아직 설명이 많이 부족하고 정리도 안됐습니다. 양해 부탁드립니다.")
+			.version("0.0.1")
+			.build();
+	}
+
+	private SecurityContext securityContext() {
+		return SecurityContext.builder()
+			.securityReferences(defaultAuth())
+			.build();
+	}
+
+	private List<SecurityReference> defaultAuth() {
+		AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
+	}
+
+	private ApiKey apiKey() {
+		return new ApiKey("Authorization", "Authorization", "header");
+	}
+
+}

--- a/src/main/java/com/glimps/glimpsserver/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/glimps/glimpsserver/common/domain/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.glimps.glimpsserver.common.domain;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public class BaseTimeEntity {
+	@CreatedDate
+	@Column(updatable = false, name ="created_at")
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/glimps/glimpsserver/common/dto/HealthCheckResponse.java
+++ b/src/main/java/com/glimps/glimpsserver/common/dto/HealthCheckResponse.java
@@ -1,0 +1,25 @@
+package com.glimps.glimpsserver.common.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HealthCheckResponse {
+
+	@Schema(description = "서버 health 상태", example = "ok", required = true)
+	private String health;
+
+	@Schema(description = "현재 실행 중인 profile", example = "[prod]", required = true)
+	private List<String> activeProfiles;
+
+	@Schema(description = "현재 요청 서버 시간", example = "2023-01-23 16:31:04", required = true)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+	private LocalDateTime currentTimeStamp;
+}

--- a/src/main/java/com/glimps/glimpsserver/common/error/AuthenticationException.java
+++ b/src/main/java/com/glimps/glimpsserver/common/error/AuthenticationException.java
@@ -1,0 +1,8 @@
+package com.glimps.glimpsserver.common.error;
+
+public class AuthenticationException extends CustomException {
+
+	public AuthenticationException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/glimps/glimpsserver/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/glimps/glimpsserver/common/filter/JwtAuthenticationFilter.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,12 +26,11 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final AuthenticationService authenticationService;
 	private final ObjectMapper mapper;
 
-	private final List<RequestMatcher> matcher;
+	private final List<RequestMatcher> matchers;
 
 	// private final RequestMatcher matcher;
 
@@ -41,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		IOException,
 		ServletException {
 
-		if (!requiresAuthentication(request, matcher)) {
+		if (!requiresAuthentication(request, matchers) || SecurityContextHolder.getContext().getAuthentication() != null) {
 			chain.doFilter(request, response);
 		} else {
 			String authorizationHeader = request.getHeader("Authorization");

--- a/src/main/java/com/glimps/glimpsserver/common/jwt/JwtUtil.java
+++ b/src/main/java/com/glimps/glimpsserver/common/jwt/JwtUtil.java
@@ -76,7 +76,7 @@ public class JwtUtil {
 			.build();
 	}
 
-	private String createAccessToken(String email, RoleType role, Date expirationTime) {
+	public String createAccessToken(String email, RoleType role, Date expirationTime) {
 		return Jwts.builder()
 			.setHeaderParam("typ", "jwt")
 			.setSubject(email)

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/ControllerErrorAdvice.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/ControllerErrorAdvice.java
@@ -1,5 +1,7 @@
 package com.glimps.glimpsserver.common.presentation;
 
+import static org.springframework.http.HttpStatus.*;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -7,6 +9,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.glimps.glimpsserver.common.dto.ErrorResponse;
 import com.glimps.glimpsserver.common.error.CustomException;
@@ -22,8 +25,8 @@ public class ControllerErrorAdvice {
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception e) {
 		log.error("Exception occurs: {}", e.getMessage());
-		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
-		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+		ErrorResponse errorResponse = ErrorResponse.of(INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+		return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(errorResponse);
 	}
 
 	@ExceptionHandler(CustomException.class)
@@ -36,8 +39,8 @@ public class ControllerErrorAdvice {
 	@ExceptionHandler(BindException.class)
 	public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
 		log.error("Exception occurs: {}", e.getMessage());
-		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getBindingResult());
-		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+		ErrorResponse errorResponse = ErrorResponse.of(BAD_REQUEST.toString(), e.getBindingResult());
+		return ResponseEntity.status(BAD_REQUEST).body(errorResponse);
 	}
 
 	/**
@@ -78,15 +81,22 @@ public class ControllerErrorAdvice {
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
 		log.error("Exception occurs: {}", e.getMessage());
-		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED.toString(), e.getMessage());
-		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+		ErrorResponse errorResponse = ErrorResponse.of(UNAUTHORIZED.toString(), e.getMessage());
+		return ResponseEntity.status(UNAUTHORIZED).body(errorResponse);
 	}
 
 	@ExceptionHandler(AccessDeniedException.class)
 	public ResponseEntity<ErrorResponse> handlerAccessDeniedException(AccessDeniedException e) {
 		log.error("Exception occurs: {}", e.getMessage());
-		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN.toString(), e.getMessage());
-		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+		ErrorResponse errorResponse = ErrorResponse.of(FORBIDDEN.toString(), e.getMessage());
+		return ResponseEntity.status(FORBIDDEN).body(errorResponse);
+	}
+
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+		log.error("Exception occurs: {}", e.getMessage());
+		ErrorResponse errorResponse = ErrorResponse.of(NOT_FOUND.toString(), e.getMessage());
+		return ResponseEntity.status(NOT_FOUND).body(errorResponse);
 	}
 
 }

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/HealthCheckController.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/HealthCheckController.java
@@ -1,17 +1,34 @@
 package com.glimps.glimpsserver.common.presentation;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.glimps.glimpsserver.common.dto.HealthCheckResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "health check", description = "서버 상태 체크 API")
 @RestController
 @RequiredArgsConstructor
 public class HealthCheckController {
 
+	private final Environment environment;
+
+	@Tag(name = "health check")
 	@GetMapping("/health")
-	public String healthCheck() {
-		return "Health is GOOD!";
+	@Operation(summary = "서버 Health Check API", description = "현재 서버가 정상적으로 기동이 된 상태인지 검사하는 API")
+	public HealthCheckResponse healthCheck() {
+		return HealthCheckResponse.builder()
+			.health("서버가 정상적인 상태입니다.")
+			.activeProfiles(Arrays.asList(environment.getActiveProfiles()))
+			.currentTimeStamp(LocalDateTime.now())
+			.build();
 	}
 
 }

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/HealthCheckController.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/HealthCheckController.java
@@ -13,14 +13,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "health check", description = "서버 상태 체크 API")
+@Tag(name = "Health check", description = "서버 상태 체크 API")
 @RestController
 @RequiredArgsConstructor
 public class HealthCheckController {
 
 	private final Environment environment;
 
-	@Tag(name = "health check")
+	@Tag(name = "Health check")
 	@GetMapping("/health")
 	@Operation(summary = "서버 Health Check API", description = "현재 서버가 정상적으로 기동이 된 상태인지 검사하는 API")
 	public HealthCheckResponse healthCheck() {

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
@@ -19,8 +19,8 @@ public class TestController {
 	@GetMapping("/test")
 	public String test(UserAuthentication userAuthentication) {
 		if (userAuthentication == null) {
-			return "userAuthentication 이 빈 값(null)입니다.";
+			return "userAuthentication is null";
 		}
-		return userAuthentication.getEmail() + "가 인증되었습니다.";
+		return userAuthentication.getEmail() + "has been authenticated.";
 	}
 }

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
@@ -6,15 +6,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.glimps.glimpsserver.common.authentication.UserAuthentication;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Test", description = "Test API")
 @RestController
 public class TestController {
 
 
+	@Operation(summary = "Test API", description = "권한이 필요한 Test API")
 	@GetMapping("/test")
 	public String test(UserAuthentication userAuthentication) {
 		if (userAuthentication == null) {
-			return "userAuthentication is null";
+			return "userAuthentication 이 빈 값(null)입니다.";
 		}
-		return userAuthentication.getEmail() + " is returned";
+		return userAuthentication.getEmail() + "가 인증되었습니다.";
 	}
 }

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/TestController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class TestController {
 
 
+	@Tag(name = "Test", description = "Test API")
 	@Operation(summary = "Test API", description = "권한이 필요한 Test API")
 	@GetMapping("/test")
 	public String test(UserAuthentication userAuthentication) {

--- a/src/main/java/com/glimps/glimpsserver/common/util/AuthorizationHeaderUtils.java
+++ b/src/main/java/com/glimps/glimpsserver/common/util/AuthorizationHeaderUtils.java
@@ -2,6 +2,7 @@ package com.glimps.glimpsserver.common.util;
 
 import org.springframework.util.StringUtils;
 
+import com.glimps.glimpsserver.common.error.AuthenticationException;
 import com.glimps.glimpsserver.common.error.CustomException;
 import com.glimps.glimpsserver.common.error.ErrorCode;
 
@@ -11,13 +12,13 @@ public class AuthorizationHeaderUtils {
 
 		// 1. authorizationHeader 필수 체크
 		if (!StringUtils.hasText(authorizationHeader)) {
-			throw new CustomException(ErrorCode.NOT_EXISTS_AUTHORIZATION);
+			throw new AuthenticationException(ErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		// 2. authorizationHeader Bearer 체크
 		String[] authorizations = authorizationHeader.split(" ");
 		if (authorizations.length < 2 || (!"Bearer".equals(authorizations[0]))) {
-			throw new CustomException(ErrorCode.NOT_VALID_BEARER_GRANT_TYPE);
+			throw new AuthenticationException(ErrorCode.NOT_VALID_BEARER_GRANT_TYPE);
 		}
 	}
 }

--- a/src/main/java/com/glimps/glimpsserver/session/application/AuthenticationService.java
+++ b/src/main/java/com/glimps/glimpsserver/session/application/AuthenticationService.java
@@ -1,6 +1,6 @@
 package com.glimps.glimpsserver.session.application;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,11 +50,6 @@ public class AuthenticationService {
 		return new UserAuthentication(email, List.of(new SimpleGrantedAuthority(role)));
 	}
 
-	// TODO 삭제 필요
-	public List<User> getRoles(String email) {
-		return userService.getAllByEmail(email);
-	}
-
 	@Transactional
 	public JwtDto oauthLogin(OAuth2User oauth2User) {
 		OAuthUserVo oauthUserVo = OAuthUserVo.from(oauth2User);
@@ -62,7 +57,7 @@ public class AuthenticationService {
 
 		User user = optionalUser.orElseGet(() -> {
 			Long id = userService.registerUser(oauthUserVo);
-			return userService.findById(id);
+			return userService.getById(id);
 		});
 
 		return issueJwt(user);
@@ -87,6 +82,13 @@ public class AuthenticationService {
 
 		return jwtUtil.createAccessTokenDto(user.getEmail(), user.getRole());
 
+	}
+
+	@Transactional
+	public Long logout(String email) {
+		User user = userService.getByEmail(email);
+		user.expireRefreshToken(LocalDateTime.now());
+		return user.getId();
 	}
 
 

--- a/src/main/java/com/glimps/glimpsserver/session/dto/AccessTokenDto.java
+++ b/src/main/java/com/glimps/glimpsserver/session/dto/AccessTokenDto.java
@@ -4,6 +4,7 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AccessTokenDto {
 
+	@Schema(description = "grantType", example = "Bearer", required = true)
 	private String grantType;
+	@Schema(description = "access Token", example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBQ0NFU1MiLCJpYXQiOjE2NjM5MTczNjQsImV4cCI6MTY2MzkxODI2NCwibWVtYmVySWQiOjEsInJvbGUiOiJBRE1JTiJ9.WVqT2UR9qSh-CqoBbq0xkUOKRYOFIwpWKeDCKMzlXXwXFie7Zt8laaDij6X2R4KxTtDNSoLoMbFkYB4h-M-wHQ", required = true)
 	private String accessToken;
+	@Schema(description = "access Token 만료 시간", example = "2022-09-23 16:31:04", required = true)
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS", timezone = "Asia/Seoul")
 	private Date accessTokenExpireTime;
 }

--- a/src/main/java/com/glimps/glimpsserver/session/dto/UserInfoDto.java
+++ b/src/main/java/com/glimps/glimpsserver/session/dto/UserInfoDto.java
@@ -1,0 +1,50 @@
+package com.glimps.glimpsserver.session.dto;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.glimps.glimpsserver.user.domain.RoleType;
+import com.glimps.glimpsserver.user.domain.User;
+import com.glimps.glimpsserver.user.domain.UserType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoDto {
+
+
+	@Schema(description = "email", example = "kim12345@naver.com", required = true)
+	private String email;
+
+	@Schema(description = "nickname", example = "닉네임", required = true)
+	private String nickname;
+	@Schema(description = "리뷰 카운트", example = "8", required = true)
+	private int reviewCnt;
+
+	@Schema(description = "역할", example = "USER", required = true)
+	private String role;
+	@Schema(description = "유저가 가입한 플랫폼", example = "KAKAO", required = true)
+	private String userType;
+
+	@Schema(description = "access Token 만료 시간", example = "2023-03-01 16:31:04.019", required = true)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS", timezone = "Asia/Seoul")
+	private LocalDateTime createdAt;
+
+
+	public static UserInfoDto of(User user) {
+		return UserInfoDto.builder()
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.reviewCnt(user.getReviewCnt())
+			.role(user.getRole().name())
+			.userType(user.getUserType().name())
+			.createdAt(user.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
+++ b/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
@@ -8,11 +8,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.glimps.glimpsserver.common.authentication.UserAuthentication;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "authentication", description = "로그아웃/토큰재발급 API")
 @RestController
 @RequestMapping("/api/v1")
 public class LogOutController {
 
-
+	@Tag(name = "authentication")
+	@Operation(summary = "로그아웃 API", description = "로그아웃시 서버 DB 내부 refresh token 만료 처리")
 	@PostMapping("/logout")
 	public Map<String, String> logout(UserAuthentication userAuthentication) {
 

--- a/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
+++ b/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
@@ -7,20 +7,29 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.glimps.glimpsserver.common.authentication.UserAuthentication;
+import com.glimps.glimpsserver.session.application.AuthenticationService;
+import com.glimps.glimpsserver.user.application.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "authentication", description = "로그아웃/토큰재발급 API")
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
 public class LogOutController {
+
+	private final AuthenticationService authenticationService;
 
 	@Tag(name = "authentication")
 	@Operation(summary = "로그아웃 API", description = "로그아웃시 서버 DB 내부 refresh token 만료 처리")
 	@PostMapping("/logout")
 	public Map<String, String> logout(UserAuthentication userAuthentication) {
 
-		return Map.of("result", "Logout succeeded");
+		String email = userAuthentication.getEmail();
+		authenticationService.logout(email);
+
+		return Map.of("result", "User(" + email +") have successfully logged out.");
 	}
 }

--- a/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
+++ b/src/main/java/com/glimps/glimpsserver/session/presentation/LogOutController.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "authentication", description = "로그아웃/토큰재발급 API")
+@Tag(name = "Authentication", description = "로그아웃/토큰재발급 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
@@ -22,7 +22,7 @@ public class LogOutController {
 
 	private final AuthenticationService authenticationService;
 
-	@Tag(name = "authentication")
+	@Tag(name = "Authentication")
 	@Operation(summary = "로그아웃 API", description = "로그아웃시 서버 DB 내부 refresh token 만료 처리")
 	@PostMapping("/logout")
 	public Map<String, String> logout(UserAuthentication userAuthentication) {

--- a/src/main/java/com/glimps/glimpsserver/session/presentation/TokenController.java
+++ b/src/main/java/com/glimps/glimpsserver/session/presentation/TokenController.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "authentication", description = "로그아웃/토큰재발급 API")
+@Tag(name = "Authentication", description = "로그아웃/토큰재발급 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
@@ -22,7 +22,7 @@ public class TokenController {
 
 	private final AuthenticationService authenticationService;
 
-	@Tag(name = "authentication")
+	@Tag(name = "Authentication")
 	@Operation(summary = "Access Token 재발급 API", description = "Access Token 재발급 API")
 	@PostMapping("/access-token/issue")
 	public AccessTokenDto logout(HttpServletRequest request) {

--- a/src/main/java/com/glimps/glimpsserver/session/presentation/TokenController.java
+++ b/src/main/java/com/glimps/glimpsserver/session/presentation/TokenController.java
@@ -10,8 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.glimps.glimpsserver.session.application.AuthenticationService;
 import com.glimps.glimpsserver.session.dto.AccessTokenDto;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "authentication", description = "로그아웃/토큰재발급 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
@@ -19,6 +22,8 @@ public class TokenController {
 
 	private final AuthenticationService authenticationService;
 
+	@Tag(name = "authentication")
+	@Operation(summary = "Access Token 재발급 API", description = "Access Token 재발급 API")
 	@PostMapping("/access-token/issue")
 	public AccessTokenDto logout(HttpServletRequest request) {
 		String authorizationHeader = request.getHeader("Authorization");

--- a/src/main/java/com/glimps/glimpsserver/user/application/UserInfoService.java
+++ b/src/main/java/com/glimps/glimpsserver/user/application/UserInfoService.java
@@ -1,0 +1,24 @@
+package com.glimps.glimpsserver.user.application;
+
+import org.springframework.stereotype.Service;
+
+import com.glimps.glimpsserver.session.dto.UserInfoDto;
+import com.glimps.glimpsserver.user.application.UserService;
+import com.glimps.glimpsserver.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class UserInfoService {
+
+	private final UserService userService;
+
+
+	public UserInfoDto getUserInfo(String email) {
+		User user = userService.getByEmail(email);
+		return UserInfoDto.of(user);
+	}
+
+
+}

--- a/src/main/java/com/glimps/glimpsserver/user/domain/User.java
+++ b/src/main/java/com/glimps/glimpsserver/user/domain/User.java
@@ -11,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import com.glimps.glimpsserver.common.domain.BaseTimeEntity;
 import com.glimps.glimpsserver.session.dto.SignUpRequest;
 
 import lombok.AccessLevel;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/glimps/glimpsserver/user/domain/User.java
+++ b/src/main/java/com/glimps/glimpsserver/user/domain/User.java
@@ -66,4 +66,7 @@ public class User {
 		this.tokenExpirationTime = refreshTokenExpireTime;
 	}
 
+	public void expireRefreshToken(LocalDateTime now) {
+		this.tokenExpirationTime = now;
+	}
 }

--- a/src/main/java/com/glimps/glimpsserver/user/presentation/UserController.java
+++ b/src/main/java/com/glimps/glimpsserver/user/presentation/UserController.java
@@ -2,6 +2,7 @@ package com.glimps.glimpsserver.user.presentation;
 
 import java.util.Map;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,8 +26,8 @@ public class UserController {
 
 	@Tag(name = "User")
 	@Operation(summary = "유저 정보 조회 API", description = "자신의 계정 조회 - 인증 필요")
-	@PostMapping("/users")
-	public UserInfoDto logout(UserAuthentication userAuthentication) {
+	@GetMapping("/users")
+	public UserInfoDto getSignedUserInfo(UserAuthentication userAuthentication) {
 		String email = userAuthentication.getEmail();
 		return userInfoService.getUserInfo(email);
 	}

--- a/src/main/java/com/glimps/glimpsserver/user/presentation/UserController.java
+++ b/src/main/java/com/glimps/glimpsserver/user/presentation/UserController.java
@@ -1,0 +1,33 @@
+package com.glimps.glimpsserver.user.presentation;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.glimps.glimpsserver.common.authentication.UserAuthentication;
+import com.glimps.glimpsserver.session.dto.UserInfoDto;
+import com.glimps.glimpsserver.user.application.UserInfoService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "User", description = "유저 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+	private final UserInfoService userInfoService;
+
+
+	@Tag(name = "User")
+	@Operation(summary = "유저 정보 조회 API", description = "자신의 계정 조회 - 인증 필요")
+	@PostMapping("/users")
+	public UserInfoDto logout(UserAuthentication userAuthentication) {
+		String email = userAuthentication.getEmail();
+		return userInfoService.getUserInfo(email);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,21 @@
+spring:
+  config:
+    use-legacy-processing: true
+  profiles:
+    include: oauth
+
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+    throw-exception-if-no-handler-found: true
+
+  web:
+    resources:
+      add-mappings: off
+
+
+token:
+  secret: VMOYV9AlhmyO8quHcWwJUE3dEa2RblfL7QZW4GYzaNZo061ZiEJ8kx8ZWuvlC6Jcj # 64바이트 이상의 문자열
+  access-token-expiration-time: 90000000  # 1500분 100000(ms) x 60(s) x 15(m)
+  refresh-token-expiration-time: 1209600000 # 2주 1000(ms) x 60 (s) x 60(m) x 24(h) x 14(d)
+      

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,11 @@ spring:
   mvc:
     path match:
       matching-strategy: ant_path_matcher
+    throw-exception-if-no-handler-found: true
+
+  web:
+    resources:
+      add-mappings: off
 
 
 token:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    use-legacy-processing: true
+  profiles:
+    include: oauth
+
+
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+    throw-exception-if-no-handler-found: true
+
+  web:
+    resources:
+      add-mappings: off
+
+
+token:
+  secret: VMOYV9AlhmyO8quHcWwJUE3dEa2RblfL7QZW4GYzaNZo061ZiEJ8kx8ZWuvlC6Jcj # 64바이트 이상의 문자열
+  access-token-expiration-time: 90000000  # 1500분 100000(ms) x 60(s) x 15(m)
+  refresh-token-expiration-time: 1209600000 # 2주 1000(ms) x 60 (s) x 60(m) x 24(h) x 14(d)
+
+server:
+  port: 80

--- a/src/test/java/com/glimps/glimpsserver/common/oauth/dto/OAuthUserVoTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/oauth/dto/OAuthUserVoTest.java
@@ -17,7 +17,7 @@ class OAuthUserVoTest {
 	private static final String NAME = "장광남";
 	private static final UserType KAKAO = UserType.KAKAO;
 
-	private OAuth2User oAuth2User = new DefaultOAuth2User(null, new HashMap<>() {{
+	private static final OAuth2User oAuth2User = new DefaultOAuth2User(null, new HashMap<>() {{
 		put("name", NAME);
 		put("email", EMAIL);
 		put("userType", KAKAO.toString().toLowerCase());

--- a/src/test/java/com/glimps/glimpsserver/common/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/presentation/HealthCheckControllerTest.java
@@ -1,0 +1,43 @@
+package com.glimps.glimpsserver.common.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.glimps.glimpsserver.common.config.SecurityConfig;
+import com.glimps.glimpsserver.common.filter.JwtAuthenticationFilter;
+
+@WebMvcTest(controllers = HealthCheckController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class})
+	})
+// @ImportAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class})
+@WithMockUser(username = "이준표", password = "",authorities = {"ROLE_USER"})
+class HealthCheckControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void HealthCheckTest() throws Exception {
+		//given
+		mockMvc.perform(get("/health"))
+			.andExpect(MockMvcResultMatchers.status().isOk());
+
+		//when
+
+		//then
+	}
+
+}

--- a/src/test/java/com/glimps/glimpsserver/common/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/presentation/HealthCheckControllerTest.java
@@ -4,26 +4,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.glimps.glimpsserver.common.config.SecurityConfig;
-import com.glimps.glimpsserver.common.filter.JwtAuthenticationFilter;
 import com.glimps.glimpsserver.testconfig.WithMockCustomUser;
 
 @WebMvcTest(controllers = HealthCheckController.class,
 	excludeFilters = {
 		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class})
 	})
-// @ImportAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class})
+	// @ImportAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class})
 class HealthCheckControllerTest {
 
 	@Autowired

--- a/src/test/java/com/glimps/glimpsserver/common/presentation/TestControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/presentation/TestControllerTest.java
@@ -1,6 +1,5 @@
 package com.glimps.glimpsserver.common.presentation;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -9,15 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.glimps.glimpsserver.common.config.SecurityConfig;
 import com.glimps.glimpsserver.testconfig.WithMockCustomUser;
-import com.glimps.glimpsserver.user.domain.RoleType;
 
 @WebMvcTest(controllers = TestController.class,
 	excludeFilters = {
@@ -38,6 +32,5 @@ class TestControllerTest {
 			.andExpect(content().string(EMAIL + "has been authenticated."));
 
 	}
-
 
 }

--- a/src/test/java/com/glimps/glimpsserver/common/presentation/TestControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/presentation/TestControllerTest.java
@@ -1,41 +1,43 @@
 package com.glimps.glimpsserver.common.presentation;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.glimps.glimpsserver.common.config.SecurityConfig;
-import com.glimps.glimpsserver.common.filter.JwtAuthenticationFilter;
 import com.glimps.glimpsserver.testconfig.WithMockCustomUser;
+import com.glimps.glimpsserver.user.domain.RoleType;
 
-@WebMvcTest(controllers = HealthCheckController.class,
+@WebMvcTest(controllers = TestController.class,
 	excludeFilters = {
 		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class})
 	})
-// @ImportAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class})
-class HealthCheckControllerTest {
-
+class TestControllerTest {
+	private static final String EMAIL = "user12345@naver.com";
+	private static final String ROLE = "ROLE_USER";
 	@Autowired
 	private MockMvc mockMvc;
 
-	@WithMockCustomUser
+	@WithMockCustomUser(userName = EMAIL, role = ROLE)
 	@Test
-	void HealthCheckTest() throws Exception {
+	void AuthenticationTest() throws Exception {
 
-		mockMvc.perform(get("/health"))
-			.andExpect(MockMvcResultMatchers.status().isOk());
+		mockMvc.perform(get("/test")).andExpect(status().isOk())
+			.andExpect(status().isOk())
+			.andExpect(content().string(EMAIL + "has been authenticated."));
 
 	}
+
 
 }

--- a/src/test/java/com/glimps/glimpsserver/common/util/AuthorizationHeaderUtilsTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/util/AuthorizationHeaderUtilsTest.java
@@ -1,0 +1,80 @@
+package com.glimps.glimpsserver.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.glimps.glimpsserver.common.error.AuthenticationException;
+import com.glimps.glimpsserver.common.error.ErrorCode;
+import com.glimps.glimpsserver.common.error.InvalidTokenException;
+
+class AuthorizationHeaderUtilsTest {
+
+	@Test
+	@DisplayName("검증하려는 Header 가 Null 이면 에러 발생")
+	void given_HeaderNull_When_Validate_Then_Error() throws Exception {
+		//given
+		final String NULL_HEADER = null;
+
+		assertThatExceptionOfType(AuthenticationException.class).isThrownBy(() -> {
+				//when
+				AuthorizationHeaderUtils.validateAuthorization(NULL_HEADER);
+			})
+			//then
+			.withMessage(ErrorCode.NOT_EXISTS_AUTHORIZATION.getMessage());
+	}
+
+	@Test
+	@DisplayName("검증하려는 Header 가 빈 문자열 이면 에러 발생")
+	void given_HeaderBlank_When_Validate_Then_Error() throws Exception {
+		//given
+		final String BLANK_HEADER = "";
+
+		assertThatExceptionOfType(AuthenticationException.class).isThrownBy(() -> {
+				//when
+				AuthorizationHeaderUtils.validateAuthorization(BLANK_HEADER);
+			})
+			//then
+			.withMessage(ErrorCode.NOT_EXISTS_AUTHORIZATION.getMessage());
+	}
+
+	@Test
+	@DisplayName("검증하려는 토큰의 타입이 Bearer가 아니면 에러 발생")
+	void given_TypeInvalid_When_Validate_Then_Error() throws Exception {
+		//given
+		final String INVALID_TYPE_TOKEN =
+			"Basic eyJ0eXAiOiJqd3QiLCJhbGciOiJIUzUxMiJ9."
+			+ "eyJzdWIiOiJ3bnN2eTYwN0BuYXZlci5jb20iLCJpYXQiOjE2Nzc0MjI0MzEsIm"
+			+ "V4cCI6MTY3ODYzMjAzMSwidG9rZW5fdHlwZSI6InJlZnJlc2hfdG9rZW4ifQ."
+			+ "XL52R6Ea00qWVG4RB78gbbSSo41sdbUbCWY_M2yLy8TBjcxaPjnHmeyf57FSsegZQ7qiR0BUTh5tGIRmoZO4jA";
+
+		assertThatExceptionOfType(AuthenticationException.class).isThrownBy(() -> {
+				//when
+				AuthorizationHeaderUtils.validateAuthorization(INVALID_TYPE_TOKEN);
+			})
+			//then
+			.withMessage(ErrorCode.NOT_VALID_BEARER_GRANT_TYPE.getMessage());
+	}
+
+	@Test
+	@DisplayName("정상적인 입력은 에러를 발생시키지 않는다")
+	void given_ValidToken_When_Validate_Then_Pass() throws Exception {
+		//given
+		final String VALID_TOKEN =
+			"Bearer eyJ0eXAiOiJqd3QiLCJhbGciOiJIUzUxMiJ9."
+				+ "eyJzdWIiOiJ3bnN2eTYwN0BuYXZlci5jb20iLCJpYXQiOjE2Nzc0MjI0MzEsIm"
+				+ "V4cCI6MTY3ODYzMjAzMSwidG9rZW5fdHlwZSI6InJlZnJlc2hfdG9rZW4ifQ."
+				+ "XL52R6Ea00qWVG4RB78gbbSSo41sdbUbCWY_M2yLy8TBjcxaPjnHmeyf57FSsegZQ7qiR0BUTh5tGIRmoZO4jA";
+
+
+		assertThatNoException().isThrownBy(() -> {
+				//when
+				AuthorizationHeaderUtils.validateAuthorization(VALID_TOKEN);
+			}
+		);
+		//then
+		// Nothing happens!
+	}
+
+}

--- a/src/test/java/com/glimps/glimpsserver/common/util/JwtUtilTest.java
+++ b/src/test/java/com/glimps/glimpsserver/common/util/JwtUtilTest.java
@@ -7,9 +7,12 @@ import java.util.Date;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.glimps.glimpsserver.common.error.ErrorCode;
+import com.glimps.glimpsserver.common.error.InvalidTokenException;
+import com.glimps.glimpsserver.common.jwt.JwtDto;
 import com.glimps.glimpsserver.common.jwt.JwtUtil;
 import com.glimps.glimpsserver.common.jwt.TokenType;
-import com.glimps.glimpsserver.common.jwt.JwtDto;
+import com.glimps.glimpsserver.session.dto.AccessTokenDto;
 import com.glimps.glimpsserver.user.domain.RoleType;
 
 import io.jsonwebtoken.Claims;
@@ -19,7 +22,15 @@ class JwtUtilTest {
 	private static final String SECRET = "ugKv3L25LnW1ndJvnUpTZQ77MxkVxqhpexelDc5mR5MmWMFyTnm8h12J8q3wn7dAE";
 	private static final String ACCESS_TOKEN_EXP_TIME = "300000";
 	private static final String REFRESH_TOKEN_EXP_TIME = "7200000";
+
+	private static final String OTHER_SECRET = "CBzJlXC1G9MLOQz7T25ixUlfBctkXMV18kj8nDtB2mcqfRCY5YAl3XXz0o0kz2s4018DYl";
+	private static final String EXPIRED_TIME = "-300000";
+
 	private final JwtUtil jwtUtil = new JwtUtil(ACCESS_TOKEN_EXP_TIME, REFRESH_TOKEN_EXP_TIME, SECRET);
+
+	private final JwtUtil jwtUtilWithInvalidKey = new JwtUtil(ACCESS_TOKEN_EXP_TIME, REFRESH_TOKEN_EXP_TIME,
+		OTHER_SECRET);
+	private final JwtUtil jwtUtilExpired = new JwtUtil(EXPIRED_TIME, EXPIRED_TIME, SECRET);
 
 	private static final String EMAIL = "wnsvy607@naver.com";
 	private static final RoleType ROLE = RoleType.USER;
@@ -27,18 +38,32 @@ class JwtUtilTest {
 	@Test
 	@DisplayName("JwtToken 발급")
 	void issueJWT() throws Exception {
+		//when
 		JwtDto jwtDto = jwtUtil.createJwtDto(EMAIL, ROLE);
 
+		//then
 		assertThat(jwtDto.getAccessToken()).isNotNull().isNotBlank();
 		assertThat(jwtDto.getRefreshToken()).isNotNull().isNotBlank();
 		assertThat(jwtDto.getAccessTokenExpireTime()).isNotNull().isAfter(new Date());
 		assertThat(jwtDto.getRefreshTokenExpireTime()).isNotNull().isAfter(new Date());
-		assertThat(jwtDto.getGrantType()).isNotNull();
+		assertThat(jwtDto.getGrantType()).isEqualTo("Bearer");
 	}
 
 	@Test
-	@DisplayName("발급된 Jwt Decode")
-	void decodeAccessToken() throws Exception {
+	@DisplayName("액세스 토큰 발급시 예외가 발생하지 않는다.")
+	void issueAccessToken() throws Exception {
+		//when
+		AccessTokenDto accessTokenDto = jwtUtil.createAccessTokenDto(EMAIL, ROLE);
+
+		//then
+		assertThat(accessTokenDto.getAccessToken()).isNotNull().isNotBlank();
+		assertThat(accessTokenDto.getAccessTokenExpireTime()).isNotNull().isAfter(new Date());
+		assertThat(accessTokenDto.getGrantType()).isEqualTo("Bearer");
+	}
+
+	@Test
+	@DisplayName("유효한 JWT를 Decode하면 Encode한 것과 동일한 Claim을 얻는다.")
+	void Given_ValidToken_When_DecodeToken_Then_GetEqualClaims() throws Exception {
 		//given
 		JwtDto jwtDto = jwtUtil.createJwtDto(EMAIL, ROLE);
 
@@ -54,8 +79,48 @@ class JwtUtilTest {
 		assertThat(accessTokenClaims.get("role")).isEqualTo(ROLE.toString());
 	}
 
-	/**
-	 * TODO 만료 테스트도 추가할 필요가 있음
-	 */
+	@Test
+	@DisplayName("만료된 JWT를 Decode하면 에러 발생")
+	void Given_ExpiredToken_When_DecodeToken_Then_Error() throws Exception {
+		//given
+		JwtDto jwtDto = jwtUtilExpired.createJwtDto(EMAIL, ROLE);
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				jwtUtil.decode(jwtDto.getAccessToken());
+			})
+			//then
+			.withMessage(ErrorCode.TOKEN_EXPIRED.getMessage());
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				jwtUtil.decode(jwtDto.getRefreshToken());
+			})
+			//then
+			.withMessage(ErrorCode.TOKEN_EXPIRED.getMessage());
+
+	}
+
+	@Test
+	@DisplayName("signature가 다른 JWT를 Decode하면 에러 발생")
+	void Given_DifferentSignatureToken_When_DecodeToken_Then_Error() throws Exception {
+		//given
+		JwtDto jwtDto = jwtUtilWithInvalidKey.createJwtDto(EMAIL, ROLE);
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				jwtUtil.decode(jwtDto.getAccessToken());
+			})
+			//then
+			.withMessage(ErrorCode.INVALID_TOKEN.getMessage());
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				jwtUtil.decode(jwtDto.getRefreshToken());
+			})
+			//then
+			.withMessage(ErrorCode.INVALID_TOKEN.getMessage());
+
+	}
 
 }

--- a/src/test/java/com/glimps/glimpsserver/testconfig/WithMockCustomUser.java
+++ b/src/test/java/com/glimps/glimpsserver/testconfig/WithMockCustomUser.java
@@ -1,0 +1,14 @@
+package com.glimps.glimpsserver.testconfig;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+	String role() default "ROLE_USER";
+	String userName() default "user12345@naver.com";
+
+}

--- a/src/test/java/com/glimps/glimpsserver/testconfig/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/glimps/glimpsserver/testconfig/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,25 @@
+package com.glimps.glimpsserver.testconfig;
+
+import java.util.List;
+import java.util.Stack;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import com.glimps.glimpsserver.common.authentication.UserAuthentication;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+	@Override
+	public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+		final SecurityContext context = SecurityContextHolder.getContext();
+		UserAuthentication authentication = new UserAuthentication(annotation.userName(),
+			List.of(new SimpleGrantedAuthority(annotation.role())));
+
+		context.setAuthentication(authentication);
+		return context;
+	}
+
+}

--- a/src/test/java/com/glimps/glimpsserver/user/application/UserInfoServiceTest.java
+++ b/src/test/java/com/glimps/glimpsserver/user/application/UserInfoServiceTest.java
@@ -1,0 +1,60 @@
+package com.glimps.glimpsserver.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.glimps.glimpsserver.session.dto.UserInfoDto;
+import com.glimps.glimpsserver.user.domain.RoleType;
+import com.glimps.glimpsserver.user.domain.User;
+import com.glimps.glimpsserver.user.domain.UserType;
+
+@ExtendWith(MockitoExtension.class)
+class UserInfoServiceTest {
+
+	private static final String EMAIL = "wnsvy607@naver.com";
+	private static final String NAME = "이준표";
+	private static final UserType KAKAO = UserType.KAKAO;
+	private static final RoleType ROLE = RoleType.USER;
+	private static final int REVIEW_CNT = 8;
+	private static final User USER = User.builder()
+		.email(EMAIL)
+		.nickname(NAME)
+		.userType(KAKAO)
+		.reviewCnt(REVIEW_CNT)
+		.role(ROLE)
+		.build();
+
+	@Mock
+	private UserService userService;
+
+	@InjectMocks
+	private UserInfoService userInfoService;
+
+	@Test
+	void given_Email_WhenGetUserInfo_Then_EqualToUser() throws Exception {
+	    //given
+		given(userService.getByEmail(EMAIL)).willReturn(USER);
+
+	    //when
+		UserInfoDto userInfo = userInfoService.getUserInfo(USER.getEmail());
+
+		//then
+		assertThat(userInfo.getEmail()).isEqualTo(EMAIL);
+		assertThat(userInfo.getNickname()).isEqualTo(NAME);
+		assertThat(userInfo.getUserType()).isEqualTo(KAKAO.name());
+		assertThat(userInfo.getRole()).isEqualTo(ROLE.name());
+		assertThat(userInfo.getReviewCnt()).isEqualTo(REVIEW_CNT);
+	// 	createdAt은 검증 비용이 너무 큼
+	}
+
+
+}

--- a/src/test/java/com/glimps/glimpsserver/user/application/UserServiceTest.java
+++ b/src/test/java/com/glimps/glimpsserver/user/application/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.glimps.glimpsserver.user.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,7 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.glimps.glimpsserver.common.error.ErrorCode;
+import com.glimps.glimpsserver.common.error.InvalidTokenException;
 import com.glimps.glimpsserver.common.error.UserDuplicationException;
+import com.glimps.glimpsserver.common.jwt.JwtUtil;
 import com.glimps.glimpsserver.session.dto.SignUpRequest;
 import com.glimps.glimpsserver.user.domain.RoleType;
 import com.glimps.glimpsserver.user.domain.User;
@@ -27,6 +30,11 @@ class UserServiceTest {
 	private static final String EMAIL = "wnsvy607@naver.com";
 	private static final String NAME = "이준표";
 	private static final UserType KAKAO = UserType.KAKAO;
+	private static final String REFRESH_TOKEN = "refresh_token";
+	private static final LocalDateTime EXPIRED_DATE = LocalDateTime.now().minusHours(1);
+	private static final LocalDateTime NOW = LocalDateTime.now();
+
+
 	private static final User EXIST_USER = User.builder()
 		.id(ID)
 		.email(EMAIL)
@@ -35,6 +43,12 @@ class UserServiceTest {
 		.role(RoleType.USER)
 		.reviewCnt(0)
 		.build();
+
+	private static final User EXPIRED_USER = User.builder()
+		.tokenExpirationTime(EXPIRED_DATE)
+		.refreshToken(REFRESH_TOKEN)
+		.build();
+
 
 	@Mock
 	private UserRepository userRepository;
@@ -47,7 +61,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("회원가입 중 이메일 중복 => 예외 발생")
-	public void validateDuplicationWhenSignUp() {
+	public void given_UserExist_When_TrySignUp_Then_Error() {
 		//given
 		given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(EXIST_USER));
 		given(signUpRequest.getEmail()).willReturn(EMAIL);
@@ -61,5 +75,34 @@ class UserServiceTest {
 			//then
 			.withMessage(ErrorCode.ALREADY_REGISTERED_USER.getMessage());
 	}
+
+	@Test
+	@DisplayName("리프레시 토큰에 매칭되는 유저가 DB에 없을 경우 에러 발생")
+	public void given_UserNotExist_When_getByRefreshToken_Then_Error() {
+		//given
+		given(userRepository.findByRefreshToken(REFRESH_TOKEN)).willReturn(Optional.empty());
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				userService.getByRefreshToken(REFRESH_TOKEN);
+			})
+			//then
+			.withMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("DB의 토큰이 만료된 경우 에러 발생")
+	public void given_DBTokenExpired_When_getByRefreshToken_Then_Error() {
+		//given
+		given(userRepository.findByRefreshToken(REFRESH_TOKEN)).willReturn(Optional.of(EXPIRED_USER));
+
+		assertThatExceptionOfType(InvalidTokenException.class).isThrownBy(() -> {
+				//when
+				userService.getByRefreshToken(REFRESH_TOKEN);
+			})
+			//then
+			.withMessage(ErrorCode.REFRESH_TOKEN_EXPIRED.getMessage());
+	}
+
 
 }

--- a/src/test/java/com/glimps/glimpsserver/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/user/presentation/UserControllerTest.java
@@ -1,0 +1,75 @@
+package com.glimps.glimpsserver.user.presentation;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.glimps.glimpsserver.common.config.SecurityConfig;
+import com.glimps.glimpsserver.session.dto.UserInfoDto;
+import com.glimps.glimpsserver.testconfig.WithMockCustomUser;
+import com.glimps.glimpsserver.user.application.UserInfoService;
+import com.glimps.glimpsserver.user.domain.RoleType;
+import com.glimps.glimpsserver.user.domain.UserType;
+
+@WebMvcTest(controllers = UserController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class})
+	})
+class UserControllerTest {
+
+	private static final String EMAIL = "wnsvy607@naver.com";
+	private static final String nickname = "이준표";
+	private static final String ROLE = RoleType.USER.toString();
+	private static final String USER_TYPE = UserType.KAKAO.name();
+	private static final int REVIEW_CNT = 10;
+	private static final LocalDateTime CREATED_AT = LocalDateTime.now().minusMonths(1);
+	private static final UserInfoDto USER_INFO_DTO =
+		UserInfoDto.builder()
+			.email(EMAIL)
+			.nickname(nickname)
+			.role(ROLE)
+			.userType(USER_TYPE)
+			.reviewCnt(REVIEW_CNT)
+			.createdAt(CREATED_AT)
+			.build();
+
+	@MockBean
+	private UserInfoService userInfoService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@WithMockCustomUser(userName = EMAIL)
+	@Test
+	void given_Authenticated_When_User_Then_Return() throws Exception {
+		//given
+		given(userInfoService.getUserInfo(EMAIL)).willReturn(USER_INFO_DTO);
+
+		//when
+		mockMvc.perform(get("/api/v1/users"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.email").value(EMAIL))
+			.andExpect(jsonPath("$.nickname").value(nickname))
+			.andExpect(jsonPath("$.reviewCnt").value(REVIEW_CNT))
+			.andExpect(jsonPath("$.role").value(ROLE))
+			.andExpect(jsonPath("$.userType").value(USER_TYPE))
+			.andExpect(jsonPath("$.createdAt").exists())
+			.andDo(print());
+
+		//then
+		verify(userInfoService).getUserInfo(EMAIL);
+
+	}
+
+}


### PR DESCRIPTION
API
---
- [x] 액세스 토큰 재발급
- [x] 로그아웃
- [x] 유저 정보 단건 조회
---

Test
---
- [x] 리프레시 토큰으로 찾은 유저가 없는 경우
- [x] DB의 리프레시 토큰이 만료된 경우 (진짜 만료 or 로그아웃)
- [x] AuthorizationHeaderUtils 4가지 경우 Test
- [x] jwtUtil accestoken 발급 test
- [x] 로그아웃 결과 테스트
- [x] 유저 정보 단건 조회 테스트
- [x] Health, TestController 테스트
- [x] TokenController
- [x] LogoutController
- [x] UserController /api/v1/users