### PR TITLE
Feat: add `introduction` field to perfume entity & fix EntityNotFound…

### DIFF
--- a/src/main/java/com/glimps/glimpsserver/common/dev/DevelopmentEnvMaker.java
+++ b/src/main/java/com/glimps/glimpsserver/common/dev/DevelopmentEnvMaker.java
@@ -62,12 +62,12 @@ public class DevelopmentEnvMaker {
 			.orderNum(0)
 			.build();
 
-		Perfume no5 = Perfume.createPerfume(brand, "NO.5");
+		Perfume no5 = Perfume.createPerfume(brand, "NO.5", "Channel의 NO.5 향수는 어쩌구 저쩌구...");
 		no5.updateRatings(5, 4.5, 4, 3);
 		no5.addPhoto(photo1);
 		perfumeRepository.save(no5);
 
-		Perfume one = Perfume.createPerfume(ck, "ONE");
+		Perfume one = Perfume.createPerfume(ck, "ONE", "CK의 ONE 향수는 어쩌구 저쩌구...");
 		one.updateRatings(4.5,4.2, 3, 1);
 		one.addPhoto(photo2);
 		perfumeRepository.save(one);

--- a/src/main/java/com/glimps/glimpsserver/common/error/EntityNotFoundException.java
+++ b/src/main/java/com/glimps/glimpsserver/common/error/EntityNotFoundException.java
@@ -1,34 +1,10 @@
 package com.glimps.glimpsserver.common.error;
 
-import java.util.UUID;
-
 import lombok.Getter;
 
 @Getter
 public class EntityNotFoundException extends CustomException {
-	// TODO Entity에 따라 보여줄 정보를 다르게 해야함
-	private Long id;
-	private String email;
-	private UUID uuid;
-
-	public EntityNotFoundException(ErrorCode errorCode, Long id, String email) {
+	public EntityNotFoundException(ErrorCode errorCode) {
 		super(errorCode);
-		this.id = id;
-		this.email = email;
-	}
-
-	public EntityNotFoundException(ErrorCode errorCode, Long id) {
-		super(errorCode);
-		this.id = id;
-	}
-
-	public EntityNotFoundException(ErrorCode errorCode, String email) {
-		super(errorCode);
-		this.email = email;
-	}
-
-	public EntityNotFoundException(ErrorCode errorCode, UUID uuid) {
-		super(errorCode);
-		this.uuid = uuid;
 	}
 }

--- a/src/main/java/com/glimps/glimpsserver/common/presentation/ControllerErrorAdvice.java
+++ b/src/main/java/com/glimps/glimpsserver/common/presentation/ControllerErrorAdvice.java
@@ -47,14 +47,13 @@ public class ControllerErrorAdvice {
 
 	/**
 	 * Entity 를 DB로부터 못찾을 경우 발생하는 에러 처리
-	 * TODO 어떤 Entity 인지 나타내도록 코드 수정 필요
 	 */
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
 		// 로그에는 ID, EMAIL 전부 노출, 반환값으로는 EMAIL만 노출
-		log.error("Exception occurs: {}, Id: {}, Email: {}", e.getMessage(), e.getId(), e.getEmail());
+		log.error("Exception occurs: {}", e.getMessage());
 		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().getCode(),
-			e.getMessage() + " Email: " + e.getEmail());
+			e.getMessage());
 		return ResponseEntity.status(e.getErrorCode().getStatus()).body(errorResponse);
 	}
 

--- a/src/main/java/com/glimps/glimpsserver/perfume/application/PerfumeService.java
+++ b/src/main/java/com/glimps/glimpsserver/perfume/application/PerfumeService.java
@@ -64,12 +64,12 @@ public class PerfumeService {
 
 	private Perfume findPerfume(UUID perfumeUuid) {
 		return perfumeRepository.findByUuid(perfumeUuid)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PERFUME_NOT_FOUND, perfumeUuid));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PERFUME_NOT_FOUND));
 	}
 
 	private Perfume findPerfumeWithEntities(UUID perfumeUuid) {
 		return perfumeRepository.findPerfumeWithEntities(perfumeUuid)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PERFUME_NOT_FOUND, perfumeUuid));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PERFUME_NOT_FOUND));
 	}
 
 	public List<PerfumeResponse> getAll() {

--- a/src/main/java/com/glimps/glimpsserver/perfume/domain/Perfume.java
+++ b/src/main/java/com/glimps/glimpsserver/perfume/domain/Perfume.java
@@ -44,12 +44,14 @@ public class Perfume {
 
 	private String perfumeName;
 
+	private String introduction;
 	private double overallRatings;
 	private double longevityRatings;
 	private double sillageRatings;
 	private double scentRatings;
 
 	private int reviewCnt;
+
 
 	@OneToMany(mappedBy = "perfume", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<PerfumeNote> perfumeNotes = new ArrayList<>();
@@ -58,7 +60,7 @@ public class Perfume {
 	private List<PerfumePhoto> perfumePhotos = new ArrayList<>();
 
 	@Builder
-	public Perfume(UUID uuid, Brand brand, String perfumeName, double overallRatings, double scentRatings,
+	public Perfume(UUID uuid, Brand brand, String perfumeName, String introduction, double overallRatings, double scentRatings,
 		double longevityRatings, double sillageRatings, int reviewCnt) {
 		this.uuid = uuid;
 		this.brand = brand;
@@ -68,13 +70,15 @@ public class Perfume {
 		this.sillageRatings = sillageRatings;
 		this.reviewCnt = reviewCnt;
 		this.scentRatings = scentRatings;
+		this.introduction = introduction;
 	}
 
-	public static Perfume createPerfume(Brand brand, String perfumeName) {
+	public static Perfume createPerfume(Brand brand, String perfumeName, String introduction) {
 		return Perfume.builder()
 			.uuid(UUID.randomUUID())
 			.brand(brand)
 			.perfumeName(perfumeName)
+			.introduction(introduction)
 			.overallRatings(0)
 			.scentRatings(0)
 			.longevityRatings(0)

--- a/src/main/java/com/glimps/glimpsserver/perfume/dto/PerfumeResponse.java
+++ b/src/main/java/com/glimps/glimpsserver/perfume/dto/PerfumeResponse.java
@@ -27,7 +27,7 @@ public class PerfumeResponse {
 	private String brandNameKor;
 
 	private String perfumeName;
-
+	private String introduction;
 	private double overallRatings;
 	private double scentRatings;
 	private double longevityRatings;
@@ -37,6 +37,10 @@ public class PerfumeResponse {
 	private List<NoteResponse> notes = new ArrayList<>();
 	private List<PerfumePhotoResponse> photos = new ArrayList<>();
 
+	public static PerfumeResponse of(Perfume perfume) {
+		return PerfumeResponse.of(perfume, new ArrayList<>());
+	}
+
 	public static PerfumeResponse of(Perfume perfume, List<Note> notes) {
 		return PerfumeResponse.builder()
 			.uuid(perfume.getUuid())
@@ -44,6 +48,7 @@ public class PerfumeResponse {
 			.brandName(perfume.getBrand().getBrandNameEng())
 			.brandNameKor(perfume.getBrand().getBrandNameKor())
 			.perfumeName(perfume.getPerfumeName())
+			.introduction(perfume.getIntroduction())
 			.overallRatings(perfume.getOverallRatings())
 			.scentRatings(perfume.getScentRatings())
 			.longevityRatings(perfume.getLongevityRatings())
@@ -54,21 +59,7 @@ public class PerfumeResponse {
 			.build();
 	}
 
-	public static PerfumeResponse of(Perfume perfume) {
-		return PerfumeResponse.builder()
-			.uuid(perfume.getUuid())
-			.brandId(perfume.getBrand().getId())
-			.brandName(perfume.getBrand().getBrandNameEng())
-			.brandNameKor(perfume.getBrand().getBrandNameKor())
-			.perfumeName(perfume.getPerfumeName())
-			.overallRatings(perfume.getOverallRatings())
-			.scentRatings(perfume.getScentRatings())
-			.longevityRatings(perfume.getLongevityRatings())
-			.sillageRatings(perfume.getSillageRatings())
-			.reviewCnt(perfume.getReviewCnt())
-			.photos(perfume.getPerfumePhotos().stream().map(PerfumePhotoResponse::of).collect(Collectors.toList()))
-			.build();
-	}
+
 
 	@QueryProjection
 	public PerfumeResponse(Perfume perfume, Brand brand, List<Note> notes, List<PerfumePhoto> photos) {
@@ -77,6 +68,7 @@ public class PerfumeResponse {
 		this.brandName = brand.getBrandNameEng();
 		this.brandNameKor = brand.getBrandNameKor();
 		this.perfumeName = perfume.getPerfumeName();
+		this.introduction = perfume.getIntroduction();
 		this.overallRatings = perfume.getOverallRatings();
 		this.scentRatings = perfume.getScentRatings();
 		this.longevityRatings = perfume.getLongevityRatings();

--- a/src/main/java/com/glimps/glimpsserver/review/application/ReviewHeartService.java
+++ b/src/main/java/com/glimps/glimpsserver/review/application/ReviewHeartService.java
@@ -32,7 +32,7 @@ public class ReviewHeartService {
 	@Transactional
 	public ReviewHeart cancelReviewHeart(Review review, User user) {
 		ReviewHeart reviewHeart = reviewHeartCustomRepository.findByReviewAndUser(review.getUuid(), user.getId())
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.REVIEW_HEART_NOT_FOUND, review.getUuid()));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.REVIEW_HEART_NOT_FOUND));
 		reviewHeart.cancelReviewHeart();
 		reviewHeartRepository.delete(reviewHeart);
 		return reviewHeart;

--- a/src/main/java/com/glimps/glimpsserver/review/application/ReviewService.java
+++ b/src/main/java/com/glimps/glimpsserver/review/application/ReviewService.java
@@ -114,7 +114,7 @@ public class ReviewService {
 
 	private Review findReview(UUID uuid) {
 		return reviewCustomRepository.findByUuid(uuid)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND, uuid));
+				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND));
 	}
 
 	public Review updateReview(UUID uuid, ReviewUpdateRequest reviewUpdateRequest, String email) {

--- a/src/main/java/com/glimps/glimpsserver/review/presentation/ReviewController.java
+++ b/src/main/java/com/glimps/glimpsserver/review/presentation/ReviewController.java
@@ -42,7 +42,6 @@ public class ReviewController {
 	@ApiOperation(value = "리뷰 생성", notes = "리뷰를 생성합니다. (권한: ROLE_USER)")
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
-	@PreAuthorize("isAuthenticated() and hasAuthority('ROLE_USER')")
 	public ReviewResponse create(@RequestBody @Valid ReviewCreateRequest reviewCreateRequest,
 			UserAuthentication userAuthentication) {
 		String email = userAuthentication.getEmail();

--- a/src/main/java/com/glimps/glimpsserver/user/application/UserService.java
+++ b/src/main/java/com/glimps/glimpsserver/user/application/UserService.java
@@ -32,7 +32,7 @@ public class UserService {
 
 	public User getUserByEmail(String email) {
 		return userRepository.findByEmail(email)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, email));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	public Optional<User> getOptionalUserByEmail(String email) {
@@ -45,7 +45,7 @@ public class UserService {
 		validateDuplicateUser(user);
 		User savedUser = userRepository.save(user);
 
-		log.info("The new user registered email={}	role={}	provider={}", savedUser.getEmail(),
+		log.info("The new user registered email={}\trole={}\tprovider={}", savedUser.getEmail(),
 			savedUser.getRole(),
 			savedUser.getUserType());
 
@@ -65,12 +65,12 @@ public class UserService {
 
 	public User getByEmail(String email) {
 		return userRepository.findByEmail(email)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, null, email));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	public User getById(Long id) {
 		return userRepository.findById(id)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, id, "UNKNOWN"));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	@Transactional

--- a/src/test/java/com/glimps/glimpsserver/perfume/presentation/PerfumeControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/perfume/presentation/PerfumeControllerTest.java
@@ -101,7 +101,7 @@ class PerfumeControllerTest {
 	void given_InvalidUUID_When_GetPerfume_Then_404Fail() throws Exception {
 		//given
 		given(perfumeService.getPerfumeWithNotesAndBrand(NOT_EXIST_UUID)).willThrow(new EntityNotFoundException(
-			ErrorCode.PERFUME_NOT_FOUND, NOT_EXIST_UUID));
+			ErrorCode.PERFUME_NOT_FOUND));
 
 		//when
 		mockMvc.perform(get("/perfumes/" + NOT_EXIST_UUID))

--- a/src/test/java/com/glimps/glimpsserver/review/domain/ReviewTest.java
+++ b/src/test/java/com/glimps/glimpsserver/review/domain/ReviewTest.java
@@ -29,7 +29,7 @@ class ReviewTest {
 		.role(RoleType.USER)
 		.build();
 
-	private static final Perfume perfume = Perfume.createPerfume(TEST_BRAND, "No.5");
+	private static final Perfume perfume = Perfume.createPerfume(TEST_BRAND, "No.5", "테스트");
 
 	@Test
 	void createReview() {

--- a/src/test/java/com/glimps/glimpsserver/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/glimps/glimpsserver/review/presentation/ReviewControllerTest.java
@@ -236,7 +236,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.getReviewById(any())).willThrow(new EntityNotFoundException(
-					ErrorCode.REVIEW_NOT_FOUND, NOT_EXISTS_REVIEW_UUID));
+					ErrorCode.REVIEW_NOT_FOUND));
 			}
 
 			@Test
@@ -351,7 +351,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.getPerfumeReviews(NOT_EXISTS_PERFUME_UUID)).willThrow(new EntityNotFoundException(
-					ErrorCode.PERFUME_NOT_FOUND, NOT_EXISTS_PERFUME_UUID));
+					ErrorCode.PERFUME_NOT_FOUND));
 			}
 
 			@Test
@@ -506,7 +506,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.getMyReviews(any(ReviewPageParam.class), eq(NOT_EXISTS_EMAIL)))
-					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL));
+					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 			}
 
 			@Test
@@ -574,7 +574,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.createHeart(eq(NOT_EXISTS_REVIEW_UUID), any())).willThrow(
-					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND, EXISTS_REVIEW_UUID)
+					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND)
 				);
 			}
 
@@ -595,7 +595,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.createHeart(any(), eq(NOT_EXISTS_EMAIL)))
-					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL));
+					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 			}
 
 			@Test
@@ -638,7 +638,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.cancelHeart(eq(NOT_EXISTS_REVIEW_UUID), any())).willThrow(
-					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND, EXISTS_REVIEW_UUID)
+					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND)
 				);
 			}
 
@@ -659,7 +659,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.cancelHeart(any(), eq(NOT_EXISTS_EMAIL)))
-					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL));
+					.willThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 			}
 
 			@Test
@@ -767,7 +767,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.createReview(any(), any())).willThrow(
-					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL)
+					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND)
 				);
 			}
 
@@ -860,7 +860,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.updateReview(any(), any(ReviewUpdateRequest.class), any())).willThrow(
-					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND, NOT_EXISTS_REVIEW_UUID)
+					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND)
 				);
 			}
 
@@ -894,7 +894,7 @@ class ReviewControllerTest {
 			void setUp() {
 				given(
 					reviewService.updateReview(any(), any(ReviewUpdateRequest.class), eq(NOT_EXISTS_EMAIL))).willThrow(
-					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL)
+					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND)
 				);
 			}
 
@@ -944,7 +944,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.deleteReview(any(), any())).willThrow(
-					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND, NOT_EXISTS_REVIEW_UUID)
+					new EntityNotFoundException(ErrorCode.REVIEW_NOT_FOUND)
 				);
 			}
 
@@ -968,7 +968,7 @@ class ReviewControllerTest {
 			@BeforeEach
 			void setUp() {
 				given(reviewService.deleteReview(any(), eq(NOT_EXISTS_EMAIL))).willThrow(
-					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND, NOT_EXISTS_EMAIL)
+					new EntityNotFoundException(ErrorCode.USER_NOT_FOUND)
 				);
 			}
 


### PR DESCRIPTION
- Add the `introduction` String field to `Perfume` Entity. 
- Fix EntityNotFoundException
  - It has unused fields like `email`, `id` , `uuid` and removed them.
  - To notify the client of the identifier of the entity that cannot be found, need to use different way, such as inheritance.